### PR TITLE
feat: 리크루트 스타일 개선

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,6 +9,7 @@ const config = {
   tabWidth: 2,
   trailingComma: 'all',
   plugins: ['prettier-plugin-tailwindcss'],
+  tailwindAttributes: ['.*Styles', '.*Style'],
 };
 
 module.exports = config;

--- a/apps/web/src/app/recruit/[[...slug]]/layout.tsx
+++ b/apps/web/src/app/recruit/[[...slug]]/layout.tsx
@@ -1,0 +1,15 @@
+import { FC, ReactNode } from 'react';
+
+interface RecruitLayoutProps {
+  children: ReactNode;
+}
+
+const RecruitLayout: FC<RecruitLayoutProps> = ({ children }) => {
+  return (
+    <div className='flex justify-center'>
+      <div className='w-[80rem] px-[2.4rem]'>{children}</div>
+    </div>
+  );
+};
+
+export default RecruitLayout;

--- a/apps/web/src/app/recruit/[[...slug]]/page.tsx
+++ b/apps/web/src/app/recruit/[[...slug]]/page.tsx
@@ -34,7 +34,7 @@ const RecruitPage: FC<RecruitPageProps> = async ({ params: { slug = [] } }) => {
   }
 
   return (
-    <div>
+    <div className='whitespace-pre-wrap'>
       {pageId && <h1>{title}</h1>}
       <div>{JSON.stringify(path)}</div>
       <BlockRenderer
@@ -46,6 +46,7 @@ const RecruitPage: FC<RecruitPageProps> = async ({ params: { slug = [] } }) => {
             {name}
           </Link>
         )}
+        renderContainer={(children) => <div className='flex flex-col'>{children}</div>}
       />
     </div>
   );

--- a/apps/web/src/components/notion/unofficial/TextRenderer.tsx
+++ b/apps/web/src/components/notion/unofficial/TextRenderer.tsx
@@ -9,23 +9,42 @@ interface TextRendererProps {
 }
 
 const TextRenderer: FC<TextRendererProps> = ({ text = [] }) => {
-  return text.map(([text, deco], idx) => {
+  return text.map(([c, deco], idx) => {
     if (!deco) {
-      return text;
+      return c;
     }
 
     const linkDeco = deco.find((v): v is LinkFormat => v[0] === 'a');
     if (linkDeco) {
       return (
         <a key={idx} href={linkDeco[1]} target='_blank' className={clsx(getSubdecoClass(deco))}>
-          {text}
+          {c}
         </a>
+      );
+    }
+
+    if (deco.find((v) => v[0] === 'c')) {
+      const isLeftCode = idx > 0 && hasType(text[idx - 1][1], 'c');
+      const isRightCode = idx < text.length - 1 && hasType(text[idx + 1][1], 'c');
+
+      return (
+        <span
+          key={idx}
+          className={clsx(
+            'rounded bg-[rgba(135,131,120,0.15)] py-[0.1rem] text-[#a33434]',
+            !isLeftCode && 'rounded-l-[0.3rem] pl-[0.7rem]',
+            !isRightCode && 'rounded-r-[0.3rem] pr-[0.7rem]',
+          )}
+          {...{ 'data-role': 'code' }}
+        >
+          <span className={clsx(getSubdecoClass(deco), 'text-[1.6rem]')}>{c}</span>
+        </span>
       );
     }
 
     return (
       <span key={idx} className={clsx(getSubdecoClass(deco))}>
-        {text}
+        {c}
       </span>
     );
   });
@@ -58,4 +77,6 @@ function getStyle([type, extra]: SubDecoration) {
   return '';
 }
 
-<div className='text-[rgba(233,233,233,0.5)] underline underline-offset-1' />;
+function hasType(subDeco: SubDecoration[] | undefined, type: SubDecoration['0']) {
+  return subDeco && subDeco.some((deco) => deco[0] === type);
+}

--- a/apps/web/src/components/notion/unofficial/TextRenderer.tsx
+++ b/apps/web/src/components/notion/unofficial/TextRenderer.tsx
@@ -49,7 +49,7 @@ function getStyle([type, extra]: SubDecoration) {
     return 'underline underline-offset-1';
   }
   if (type === 'a') {
-    return 'text-gray1 hover:text-gray0 decoration-gray0 cursor-pointer underline hover:underline-offset-1';
+    return 'text-[rgba(233,233,233,0.5)] hover:text-gray0 decoration-gray0 cursor-pointer underline hover:underline-offset-1';
   }
   if (type === 'h') {
     return colorStyles[extra] ?? '';
@@ -58,8 +58,4 @@ function getStyle([type, extra]: SubDecoration) {
   return '';
 }
 
-<div className='underline underline-offset-1' />;
-
-// function hasType(subDeco: SubDecoration[], type: SubDecoration['0']) {
-//   return subDeco.some((deco) => deco[0] === type);
-// }
+<div className='text-[rgba(233,233,233,0.5)] underline underline-offset-1' />;

--- a/apps/web/src/components/notion/unofficial/TextRenderer.tsx
+++ b/apps/web/src/components/notion/unofficial/TextRenderer.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
-import type { Decoration, SubDecoration } from 'notion-types';
+import type { Decoration, LinkFormat, SubDecoration } from 'notion-types';
 import { FC } from 'react';
+
+import { colorStyles } from './colors';
 
 interface TextRendererProps {
   text?: Decoration[];
@@ -10,6 +12,15 @@ const TextRenderer: FC<TextRendererProps> = ({ text = [] }) => {
   return text.map(([text, deco], idx) => {
     if (!deco) {
       return text;
+    }
+
+    const linkDeco = deco.find((v): v is LinkFormat => v[0] === 'a');
+    if (linkDeco) {
+      return (
+        <a key={idx} href={linkDeco[1]} target='_blank' className={clsx(getSubdecoClass(deco))}>
+          {text}
+        </a>
+      );
     }
 
     return (
@@ -30,15 +41,25 @@ function getSubdecoClass(subDeco: SubDecoration[]): string[] {
   return [getStyle(subDeco[0]), ...getSubdecoClass(subDeco.slice(1))];
 }
 
-function getStyle([type, _extra]: SubDecoration) {
+function getStyle([type, extra]: SubDecoration) {
   if (type === 'b') {
-    const newStyle = 'font-bold';
-    return newStyle;
+    return 'font-bold';
   }
   if (type === '_') {
-    const newStyle = 'underline-offset-1';
-    return newStyle;
+    return 'underline underline-offset-1';
+  }
+  if (type === 'a') {
+    return 'text-gray1 hover:text-gray0 decoration-gray0 cursor-pointer underline hover:underline-offset-1';
+  }
+  if (type === 'h') {
+    return colorStyles[extra] ?? '';
   }
 
   return '';
 }
+
+<div className='underline underline-offset-1' />;
+
+// function hasType(subDeco: SubDecoration[], type: SubDecoration['0']) {
+//   return subDeco.some((deco) => deco[0] === type);
+// }

--- a/apps/web/src/components/notion/unofficial/colors.ts
+++ b/apps/web/src/components/notion/unofficial/colors.ts
@@ -1,0 +1,22 @@
+import { Color } from 'notion-types';
+
+export const colorStyles = {
+  blue: '',
+  brown: '',
+  gray: '',
+  pink: '',
+  purple: 'text-[#7f46db]',
+  orange: 'text-[#e58046]',
+  red: '',
+  teal: 'text-[#0f7b6c]',
+  yellow: 'text-[#dfab01]',
+  blue_background: '',
+  brown_background: '',
+  gray_background: 'bg-[#37352f]',
+  orange_background: '',
+  pink_background: '',
+  purple_background: '',
+  red_background: '',
+  teal_background: '',
+  yellow_background: '',
+} satisfies Record<Color, string>;

--- a/apps/web/src/components/notion/unofficial/colors.ts
+++ b/apps/web/src/components/notion/unofficial/colors.ts
@@ -3,7 +3,7 @@ import { Color } from 'notion-types';
 export const colorStyles = {
   blue: '',
   brown: '',
-  gray: '',
+  gray: 'text-[#9b9a97]',
   pink: '',
   purple: 'text-[#7f46db]',
   orange: 'text-[#e58046]',

--- a/apps/web/src/components/recruit/recruitBlockUnofficial.tsx
+++ b/apps/web/src/components/recruit/recruitBlockUnofficial.tsx
@@ -10,28 +10,28 @@ import ToggleBlock from './ToggleBlock';
 
 export const recruitBlockComponents = {
   header: ({ block }) => (
-    <h1 className='text-[4rem] font-bold'>
+    <h1 className='mb-[1rem] mt-[3rem] text-[4rem] font-bold leading-[130%]'>
       <TextRenderer text={block.properties?.title} />
     </h1>
   ),
   sub_header: ({ block }) => (
-    <h2 className='text-[3.2rem] font-bold'>
+    <h2 className='mb-[1rem] mt-[2.4rem] text-[3.2rem] font-bold'>
       <TextRenderer text={block.properties?.title} />
     </h2>
   ),
   sub_sub_header: ({ block }) => (
-    <h3 className='text-[2.4rem] font-bold'>
+    <h3 className='mb-[1rem] mt-[1.5rem] text-[2.4rem] font-bold'>
       <TextRenderer text={block.properties?.title} />
     </h3>
   ),
   text: ({ block }) => (
-    <p className='min-h-[1em] whitespace-normal break-words text-[1.8rem]'>
+    <p className='min-h-[1em] break-words py-[0.4rem] text-[1.8rem] leading-[140%]'>
       <TextRenderer text={block.properties?.title} />
     </p>
   ),
   bulleted_list: ({ block, ctx: { renderBlocks } }) => (
     <div className='flex'>
-      <div className='pr-[8px]'>•</div>
+      <div className='pr-[8px] text-[1.8rem]'>•</div>
       <div className='flex flex-grow flex-col'>
         <div className='text-[1.8rem]'>
           <TextRenderer text={block.properties?.title} />
@@ -42,7 +42,7 @@ export const recruitBlockComponents = {
   ),
   numbered_list: ({ block, streak, ctx: { renderBlocks } }) => (
     <div className='flex'>
-      <div className='pr-[8px]'>{streak + 1}.</div>
+      <div className='pr-[8px] text-[1.8rem]'>{streak + 1}.</div>
       <div className='flex flex-grow flex-col'>
         <div className='text-[1.8rem]'>
           <TextRenderer text={block.properties?.title} />
@@ -56,7 +56,7 @@ export const recruitBlockComponents = {
   ),
   divider: () => (
     <div className='flex h-[1.3rem] w-full items-center'>
-      <div className='h-[1px] w-full border-b border-white' />
+      <div className='h-[1px] w-full border-b border-white/30' />
     </div>
   ),
   toggle: ({ block, ctx: { renderBlocks } }) => (
@@ -64,12 +64,26 @@ export const recruitBlockComponents = {
       {renderBlocks(block.content ?? [])}
     </ToggleBlock>
   ),
-  callout: ({ block, ctx: { renderBlocks } }) => (
-    <div className='flex whitespace-pre'>
-      <div className=''>{block.format.page_icon.startsWith('/') ? '' : block.format.page_icon}</div>
-      <div className='flex-grow'>{renderBlocks(block.content ?? [])}</div>
-    </div>
-  ),
+  callout: ({ block, ctx: { renderBlocks } }) => {
+    const icon = block.format.page_icon.startsWith('/') ? null : block.format.page_icon;
+
+    return (
+      <div className={clsx('flex py-[1.6rem] pr-[1.6rem]', icon && 'pl-[1.6rem]')}>
+        {icon && (
+          <div className='font-emoji flex h-[2.4rem] w-[2.4rem] items-center justify-center pr-[1rem] text-[2rem]'>
+            {icon}
+          </div>
+        )}
+        <div className='flex-grow text-[1.8rem] leading-[140%]'>
+          <div>
+            <TextRenderer text={block.properties.title} />
+          </div>
+          {renderBlocks(block.content ?? [])}
+          {/* {renderBlocks(block.content ?? [], { renderContainer: (children) => <div>{children}</div> })} */}
+        </div>
+      </div>
+    );
+  },
   column_list: ({ block, ctx: { renderBlocks } }) =>
     renderBlocks(block.content ?? [], { renderContainer: (children) => <div className='flex'>{children}</div> }),
   column: ({ block, ctx: { renderBlocks } }) =>
@@ -92,7 +106,7 @@ export const recruitBlockComponents = {
     </ContentBlock>
   ),
   page: ({ block, ctx: { renderPageLink } }) =>
-    renderPageLink({ id: block.id, name: plainText(block.properties?.title) }),
+    renderPageLink({ id: block.id, name: plainText(block.properties?.title), className: 'text-[1.8rem] px-[1rem]' }),
 } satisfies BlockComponentsBase;
 
 function plainText(text?: Decoration[]) {

--- a/apps/web/src/components/recruit/recruitBlockUnofficial.tsx
+++ b/apps/web/src/components/recruit/recruitBlockUnofficial.tsx
@@ -4,6 +4,7 @@ import { Decoration } from 'notion-types';
 import type { BlockComponentsBase } from '@/components/notion/unofficial/BlockResolver';
 
 import SyntaxHighlighter from '../notion/official/SyntaxHighlighter';
+import { colorStyles } from '../notion/unofficial/colors';
 import TextRenderer from '../notion/unofficial/TextRenderer';
 import ContentBlock from './ContentBlock';
 import ToggleBlock from './ToggleBlock';
@@ -68,7 +69,12 @@ export const recruitBlockComponents = {
     const icon = block.format.page_icon.startsWith('/') ? null : block.format.page_icon;
 
     return (
-      <div className={clsx('flex py-[1.6rem] pr-[1.6rem]', icon && 'pl-[1.6rem]')}>
+      <div
+        className={clsx(
+          'my-[0.6rem] flex rounded-lg p-[1.6rem]',
+          colorStyles[block.format.block_color] ?? 'bg-[#292929]',
+        )}
+      >
         {icon && (
           <div className='font-emoji flex h-[2.4rem] w-[2.4rem] items-center justify-center pr-[1rem] text-[2rem]'>
             {icon}
@@ -79,7 +85,6 @@ export const recruitBlockComponents = {
             <TextRenderer text={block.properties.title} />
           </div>
           {renderBlocks(block.content ?? [])}
-          {/* {renderBlocks(block.content ?? [], { renderContainer: (children) => <div>{children}</div> })} */}
         </div>
       </div>
     );
@@ -95,13 +100,14 @@ export const recruitBlockComponents = {
       ),
     }),
   image: ({ block }) => (
-    <ContentBlock format={block.format}>
+    <ContentBlock format={block.format} className='my-[1rem]'>
       <img
         src={block.properties.source[0][0]}
         alt='NotionImage'
         width={block.format?.block_width}
         height={block.format?.block_height}
         className={clsx(block.format?.block_page_width && 'w-full')}
+        style={{ aspectRatio: block.format?.block_aspect_ratio && 1 / block.format?.block_aspect_ratio }}
       />
     </ContentBlock>
   ),

--- a/apps/web/src/components/recruit/recruitBlockUnofficial.tsx
+++ b/apps/web/src/components/recruit/recruitBlockUnofficial.tsx
@@ -76,7 +76,7 @@ export const recruitBlockComponents = {
         )}
       >
         {icon && (
-          <div className='font-emoji flex h-[2.4rem] w-[2.4rem] items-center justify-center pr-[1rem] text-[2rem]'>
+          <div className='font-emoji mr-[1rem] mt-[0.2rem] flex h-[2.4rem] w-[2.4rem] items-center justify-center text-[2rem] leading-[100%]'>
             {icon}
           </div>
         )}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -27,6 +27,15 @@ module.exports = {
     fontFamily: {
       sans: ['var(--font-suit)', ...defaultTheme.fontFamily.sans],
       mono: [...defaultTheme.fontFamily.mono],
+      emoji: [
+        'Apple Color Emoji',
+        'Segoe UI Emoji',
+        'NotoColorEmoji',
+        'Noto Color Emoji',
+        'Segoe UI Symbol',
+        'Android Emoji',
+        'EmojiSymbols',
+      ],
     },
     fontSize: {
       '80-bold': ['8rem', { lineHeight: '130%', letterSpacing: '-0.16rem', fontWeight: 700 }],

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
       'pink-sub': '#8F388A',
       'yellow-sub': '#816600',
       'dark1': '#252629',
+      'gray0': '#808388',
       'gray1': '#3C3D40',
       'gray2': '#1C1D1E',
     },


### PR DESCRIPTION
리크루트 페이지의 블럭 스타일들을 변경했습니다.
<img width="839" alt="image" src="https://github.com/sopt-makers/makers-page/assets/36122585/e8c9da8a-7df9-4a4d-9f2f-b598d291e9ce">
