### PR TITLE
refactor: 메이커스 로고 애니메이션 수정

### DIFF
--- a/apps/web/src/components/mainpage/greeting/GreetingSection.tsx
+++ b/apps/web/src/components/mainpage/greeting/GreetingSection.tsx
@@ -8,8 +8,8 @@ import Missions from './Missions';
 
 export default function Greeting() {
   const { scrollYProgress } = useScroll();
-  const paddingBottomLogo = useTransform(scrollYProgress, [0, 0.01], ['35rem', '0rem']);
-  const opacityLogo = useTransform(scrollYProgress, [0, 0.01], [1, 0.5]);
+  const paddingBottomLogo = useTransform(scrollYProgress, [0, 0.07], ['35rem', '0rem']);
+  const opacityLogo = useTransform(scrollYProgress, [0, 0.07], [1, 0.5]);
 
   return (
     <div className='relative h-[770rem] md:h-[790rem]'>

--- a/apps/web/src/components/mainpage/greeting/GreetingSection.tsx
+++ b/apps/web/src/components/mainpage/greeting/GreetingSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { m, useScroll, useTransform } from 'framer-motion';
 
 import MakersLogo3D from '@/components/common/MakersLogo3D';
 
@@ -7,18 +7,24 @@ import MakersIntodution from './MakersIntodution';
 import Missions from './Missions';
 
 export default function Greeting() {
+  const { scrollYProgress } = useScroll();
+  const paddingBottomLogo = useTransform(scrollYProgress, [0, 0.01], ['35rem', '0rem']);
+  const opacityLogo = useTransform(scrollYProgress, [0, 0.01], [1, 0.5]);
+
   return (
     <div className='relative h-[770rem] md:h-[790rem]'>
       <div className='absolute inset-0'>
-        <div className='sticky top-0 flex h-[100vh] items-center justify-center pt-[8rem]'>
-          <MakersLogo3D className='h-[27rem] w-[27rem] opacity-50 md:h-[40rem] md:w-[40rem]' />
+        <div className='sticky top-0 flex h-[100vh] items-center justify-center'>
+          <m.div style={{ paddingBottom: paddingBottomLogo, opacity: opacityLogo }}>
+            <MakersLogo3D className='h-[27rem] w-[27rem] md:h-[40rem] md:w-[40rem]' />
+          </m.div>
         </div>
       </div>
-      <div className='absolute inset-0'>
-        <Intro />
+      <m.div className='absolute inset-0'>
+        <Intro className='pt-[10rem] md:pt-[20rem]' />
         <MakersIntodution />
         <Missions />
-      </div>
+      </m.div>
     </div>
   );
 }

--- a/apps/web/src/components/mainpage/greeting/Intro.tsx
+++ b/apps/web/src/components/mainpage/greeting/Intro.tsx
@@ -25,9 +25,9 @@ export default function Intro({ className }: GreetingProps) {
         transition={{ delay: 1 }}
         style={{ opacity }}
       >
-        <h1 className='md:text-64-semibold text-24-semibold mt-[6rem] text-center font-semibold'>
+        <h1 className='md:text-64-semibold text-24-semibold text-center font-semibold'>
           SOPT에 없던 새로운 가치를 <br />
-          제품을 통해 만들어갑니다.
+          프로덕트를 통해 만들어갑니다.
         </h1>
         <RecruitButton />
         <ArrowIcon />


### PR DESCRIPTION
- 메이커스 로고에 애니메이션을 적용 했습니다.
- `useScroll`과 `useTransition` 을 통해 padding-top 과 opacity 를 서서히 변경하여 컨텐츠 공백을 줄였습니다.



https://github.com/sopt-makers/makers-page/assets/97586683/1f33c17e-b15b-45e0-8cb3-87d6371304b7

